### PR TITLE
Use AWS keys if found in environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,22 @@
+.PHONY: all deps test build cover
+
+GO ?= go
+
+all: build
+
+deps:
+	${GO} get
+
+build: deps
+	${GO} build -ldflags "-s -w"
+
+test: deps
+	${GO} test -v
+
+clean:
+	@rm -rf poormanscdn *.out
+
+cover:
+	${GO} test -cover && \
+	${GO} test -coverprofile=coverage.out  && \
+	${GO} tool cover -html=coverage.out

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # poormanscdn
 
-poormanscdn is a caching proxy to Amazon S3 built using Go. It is highly performant, very easy to configure (just copy the binary) and can save you a lot of money on S3 bandwidth through caching. If you run poormanscdn on a couple of cheap dedicated servers and round-robin DNS with health-checks, you can have a highly-available CDN for very low cost.   
+poormanscdn is a caching proxy to Amazon S3 built using Go. It is highly performant, very easy to configure (just copy the binary) and can save you a lot of money on S3 bandwidth through caching. If you run poormanscdn on a couple of cheap dedicated servers and round-robin DNS with health-checks, you can have a highly-available CDN for very low cost.
 
 ## Features
 
@@ -17,10 +17,33 @@ poormanscdn is a caching proxy to Amazon S3 built using Go. It is highly perform
 ```bash
 go get github.com/alexandres/poormanscdn
 cd $GOPATH/src/github.com/alexandres/
-go build
+make
 ```
 
 This builds the `poormanscdn` standalone executable. It expects to find `config.json` in the current working directory.
+
+## running
+
+To keep it up and running across system reboots using [immortal](https://immortal.run)
+
+```yaml
+cmd: /path/to/home/poormanscdn
+cwd: /path/to/home
+env:
+  S3AccessKey: s3-access-key
+  S3SecretKey: s3-secret-key
+  SECRET: secret
+log:
+  file: /var/log/app-1.log
+  age: 86400 # seconds
+  num: 7     # int
+  size: 1    # MegaBytes
+```
+
+To daemonize and test:
+
+    immortal ./poormanscdn
+
 
 ## Configuration
 
@@ -48,7 +71,7 @@ poormanscdn must have write access to CacheDir, DatabaseDir, and TmpDir, which m
 
 ### Cache Invalidation
 
-poormanscdn invalidates a cached file if the **modified** query parameter is newer than the last modified time as given by the local filesystem. For example, passing **modified=0** means a file will never be invalidated. This should be used if your files are immutable. 
+poormanscdn invalidates a cached file if the **modified** query parameter is newer than the last modified time as given by the local filesystem. For example, passing **modified=0** means a file will never be invalidated. This should be used if your files are immutable.
 
 Note: an attacker can invalidate your files by calling download URLs with **modified=timesinceepoch**. To avoid this, please use URL signing as described below.
 

--- a/README.md
+++ b/README.md
@@ -22,27 +22,27 @@ make
 
 This builds the `poormanscdn` standalone executable. It expects to find `config.json` in the current working directory.
 
-## running
+## Run as a service
 
-To keep it up and running across system reboots using [immortal](https://immortal.run)
+To run poormanscdn as a service (persist across reboots), you can use the
+[immortal](https://immortal.run) supervisor. Here is an example immortal
+`run.yml` file
 
 ```yaml
 cmd: /path/to/home/poormanscdn
 cwd: /path/to/home
 env:
-  S3AccessKey: s3-access-key
-  S3SecretKey: s3-secret-key
-  SECRET: secret
+  AWS_ACCESS_KEY: aws-access-key
+  AWS_SECRET_ACCESS_KEY: aws-secret-key
+  PCDN_SECRET: pcdn_secret
 log:
-  file: /var/log/app-1.log
+  file: /var/log/poormanscdn.log
   age: 86400 # seconds
   num: 7     # int
   size: 1    # MegaBytes
 ```
 
-To daemonize and test:
-
-    immortal ./poormanscdn
+    immortal -l /var/log/poormanscdn.log ./poormanscdn
 
 
 ## Configuration

--- a/config.go
+++ b/config.go
@@ -25,6 +25,7 @@ package main
 import (
 	"encoding/json"
 	"errors"
+	"log"
 	"os"
 )
 
@@ -55,19 +56,22 @@ func GetConfiguration(configPath string) (conf Configuration, err error) {
 	}
 
 	// check for AWS keys in environment
-	s3AccessKey := os.Getenv("S3AccessKey")
+	s3AccessKey := os.Getenv("AWS_ACCESS_KEY")
 	if s3AccessKey != "" {
 		conf.S3AccessKey = s3AccessKey
+		log.Println("Using AWS_ACCESS_KEY from environment var")
 	}
 
-	s3SecretKey := os.Getenv("S3SecretKey")
+	s3SecretKey := os.Getenv("AWS_SECRET_ACCESS_KEY")
 	if s3SecretKey != "" {
 		conf.S3AccessKey = s3SecretKey
+		log.Println("Using AWS_SECRET_ACCESS_KEY from environment var")
 	}
 
-	secret := os.Getenv("SECRET")
+	secret := os.Getenv("PCDN_SECRET")
 	if secret != "" {
 		conf.Secret = secret
+		log.Println("Using PCDN_SECRET from environment var")
 	}
 
 	if conf.SigRequired && conf.Secret == "" {

--- a/config.go
+++ b/config.go
@@ -53,6 +53,23 @@ func GetConfiguration(configPath string) (conf Configuration, err error) {
 	if err != nil {
 		return
 	}
+
+	// check for AWS keys in environment
+	s3AccessKey := os.Getenv("S3AccessKey")
+	if s3AccessKey != "" {
+		conf.S3AccessKey = s3AccessKey
+	}
+
+	s3SecretKey := os.Getenv("S3SecretKey")
+	if s3SecretKey != "" {
+		conf.S3AccessKey = s3SecretKey
+	}
+
+	secret := os.Getenv("SECRET")
+	if secret != "" {
+		conf.Secret = secret
+	}
+
 	if conf.SigRequired && conf.Secret == "" {
 		err = errors.New("sig is required but no secret provided")
 		return

--- a/run.yml
+++ b/run.yml
@@ -1,0 +1,11 @@
+cmd: /path/to/home/poormanscdn
+cwd: /path/to/home
+env:
+  S3AccessKey: s3-access-key
+  S3SecretKey: s3-secret-key
+  SECRET: secret
+log:
+  file: /var/log/app-1.log
+  age: 86400 # seconds
+  num: 7     # int
+  size: 1    # MegaBytes


### PR DESCRIPTION
Modified config to support  AWS keys if found in the environment, can be used as a base to improve more the application.

An example of how to use [immortal run.yml](https://immortal.run/post/run.yml/) example to keep service up and running across reboots 

Small Makefile to simplify compile/test/coverage process 