### PR TITLE
Allow to read proxy variables from environment

### DIFF
--- a/s3.go
+++ b/s3.go
@@ -63,6 +63,9 @@ func (c S3Client) Read(path string, w *CacheWriter) *StorageProviderError {
 		SecretKey: c.secretKey,
 	})
 	client := http.DefaultClient
+	client.Transport = &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
+	}
 	res, err := client.Do(req)
 	if err != nil {
 		return &StorageProviderError{http.StatusServiceUnavailable, err}


### PR DESCRIPTION
I think that is interesting to pass proxy variables to allow internet access.

Tested with:

HTTP_PROXY=http://myproxy:8080
HTTPS_PROXY=http://myproxy:8080

BR

